### PR TITLE
Node v6 is required due to the use of Buffer.alloc

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "xtend": "^4.0.1"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "homepage": "https://webtorrent.io",
   "keywords": [


### PR DESCRIPTION
see https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe
and https://github.com/webtorrent/webtorrent-cli/issues/47