### PR TITLE
fix errors on signal when using --mpv

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -688,7 +688,7 @@ function gracefulExit () {
   process.removeListener('SIGINT', gracefulExit)
   process.removeListener('SIGTERM', gracefulExit)
 
-  if (!client) return
+  if (!client || client.destroyed) return
 
   if (subtitlesServer) {
     subtitlesServer.close()

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -455,7 +455,8 @@ function runDownload (torrentId) {
 
     function openPlayer (cmd) {
       unref(cp.exec(cmd, function (err) {
-        if (err) return fatalError(err)
+        // Code 4 is returned by MPV when quiting
+        if (err && err.code !== 4) return fatalError(err)
       }).on('exit', playerExit))
     }
 


### PR DESCRIPTION
When using `webtorrent` with `--mpv` option and after the player has started, killing `webtorrent` (not the player) print this:
```
webtorrent is exiting...

UNEXPECTED ERROR: If this is a bug in WebTorrent, report it!
OPEN AN ISSUE: https://github.com/webtorrent/webtorrent-cli/issues

DEBUG INFO: webtorrent-cli 1.11.0, webtorrent 0.98.24, node v6.14.1, linux x64, exit 1
/nix/store/2y8k9rsw1j9w7p73zkn9vjwiiccfzadb-node-webtorrent-cli-1.11.0/lib/node_modules/webtorrent-cli/node_modules/webtorrent/index.js:407
  if (this.destroyed) throw new Error('client already destroyed')
                      ^

Error: client already destroyed
    at WebTorrent.destroy (/nix/store/2y8k9rsw1j9w7p73zkn9vjwiiccfzadb-node-webtorrent-cli-1.11.0/lib/node_modules/webtorrent-cli/node_modules/webtorrent/index.js:407:29)
    at gracefulExit (/nix/store/2y8k9rsw1j9w7p73zkn9vjwiiccfzadb-node-webtorrent-cli-1.11.0/lib/node_modules/webtorrent-cli/bin/cmd.js:703:10)
    at ChildProcess.playerExit (/nix/store/2y8k9rsw1j9w7p73zkn9vjwiiccfzadb-node-webtorrent-cli-1.11.0/lib/node_modules/webtorrent-cli/bin/cmd.js:471:9)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:219:12)

```
This PR fix it.