### PR TITLE
open mpv w/ unique url to allow resume-playback

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -450,6 +450,7 @@ function runDownload (torrentId) {
     } else if (argv.mplayer) {
       openPlayer(MPLAYER_EXEC + ' ' + href)
     } else if (argv.mpv) {
+      href = href + '/' + torrent.infoHash + '/' + torrent.files[index].name
       openPlayer(MPV_EXEC + ' ' + href)
     } else if (argv.omx) {
       openPlayer(OMX_EXEC + ' ' + href)

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -450,7 +450,7 @@ function runDownload (torrentId) {
     } else if (argv.mplayer) {
       openPlayer(MPLAYER_EXEC + ' ' + href)
     } else if (argv.mpv) {
-      href = href + '/' + torrent.infoHash + '/' + torrent.files[index].name
+      href = href + '/' + torrent.infoHash + '/' + encodeURIComponent(torrent.files[index].name)
       openPlayer(MPV_EXEC + ' ' + href)
     } else if (argv.omx) {
       openPlayer(OMX_EXEC + ' ' + href)

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -436,6 +436,8 @@ function runDownload (torrentId) {
     if (playerName) torrent.files[index].select()
     if (argv.stdout) torrent.files[index].createReadStream().pipe(process.stdout)
 
+    href = href + '/' + torrent.infoHash + '/' + encodeURIComponent(torrent.files[index].name)
+
     if (argv.vlc) {
       vlcCommand(function (err, vlcCmd) {
         if (err) return fatalError(err)
@@ -450,7 +452,6 @@ function runDownload (torrentId) {
     } else if (argv.mplayer) {
       openPlayer(MPLAYER_EXEC + ' ' + href)
     } else if (argv.mpv) {
-      href = href + '/' + torrent.infoHash + '/' + encodeURIComponent(torrent.files[index].name)
       openPlayer(MPV_EXEC + ' ' + href)
     } else if (argv.omx) {
       openPlayer(OMX_EXEC + ' ' + href)


### PR DESCRIPTION
When launching `mpv` with webtorrent-cli, the resume-playback feature does not work because `mpv` relies on the URL being unique, but webtorrent usually serves files (across different torrents) at the same location (e.g `http://localhost:PORT/0`).

Make the URL unique by appending the torrent hash & name. This only works because the webtorrent server (`torrent.createServer(..)`) only cares about the first segment in the path (e.g. `/0/...`).