### PR TITLE
Implements file selection.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -346,6 +346,7 @@ function runDownload (torrentId) {
   var torrent = client.add(torrentId, { path: argv.out, announce: argv.announce })
 
   torrent.on('infoHash', function () {
+    torrent.so = argv.select.toString()
     if (argv.quiet) return
     updateMetadata()
     torrent.on('wire', updateMetadata)

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -346,7 +346,9 @@ function runDownload (torrentId) {
   var torrent = client.add(torrentId, { path: argv.out, announce: argv.announce })
 
   torrent.on('infoHash', function () {
-    torrent.so = argv.select.toString()
+    if ('select' in argv) {
+      torrent.so = argv.select.toString()
+    }
     if (argv.quiet) return
     updateMetadata()
     torrent.on('wire', updateMetadata)


### PR DESCRIPTION
WebTorrent-cli currently doesn't deselect any files not included in `-s` or `--select`, this causes the full torrent to be downloaded even if a single file is selected, this was pointed out in #65. 

This PR resolves this, passing the files specified in `-s` or `--select` to `torrent.so`. The variable `torrent.so`  is used during the `_onMetadata` event in the [WebTorrent library](https://github.com/webtorrent/webtorrent/blob/master/lib/torrent.js#L508) which handles the initial selection of files in a torrent.

