### PR TITLE
Show an error if there's no file with an index

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -456,6 +456,10 @@ function runDownload (torrentId) {
       ? argv.select
       : torrent.files.indexOf(torrent.files.reduce((a, b) => a.length > b.length ? a : b))
 
+    if (!torrent.files[index]) {
+      errorAndExit(`There's no file that maps to index ${index}`)
+    }
+
     onSelection(index)
   }
 


### PR DESCRIPTION
Just a small ux improvement. If a user tries to access a file with an index that's out of boundaries, we show them an error.