### PR TITLE
Fix issue of using deprecated method of mime package.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -564,7 +564,7 @@ function runDownload (torrentId) {
       dlnacasts.on('update', player => {
         const opts = {
           title: `WebTorrent - ${torrent.files[index].name}`,
-          type: mime.lookup(torrent.files[index].name)
+          type: mime.getType(torrent.files[index].name)
         }
 
         if (argv.subtitles) {


### PR DESCRIPTION
I had problem to use WebTorrent with DLNA. After some debugging I found that for DLNA we use deprecated method of mime package:

> Version 2 is a breaking change from 1.x as the semver implies. Specifically:
> lookup() renamed to getType()

https://github.com/broofa/node-mime#readme
