### PR TITLE
single quote url when launching player in subprocess

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -492,17 +492,17 @@ function runDownload (torrentId) {
         if (process.platform === 'win32') {
           openVLCWin32(vlcCmd)
         } else {
-          openPlayer(`${vlcCmd} ${href} ${VLC_ARGS}`)
+          openPlayer(`${vlcCmd} '${href}' ${VLC_ARGS}`)
         }
       })
     } else if (argv.iina) {
-      openIINA(`${IINA_EXEC} ${href}`, `iina://weblink?url=${href}`)
+      openIINA(`${IINA_EXEC} '${href}'`, `iina://weblink?url=${href}`)
     } else if (argv.mplayer) {
-      openPlayer(`${MPLAYER_EXEC} ${href}`)
+      openPlayer(`${MPLAYER_EXEC} '${href}'`)
     } else if (argv.mpv) {
-      openPlayer(`${MPV_EXEC} ${href}`)
+      openPlayer(`${MPV_EXEC} '${href}'`)
     } else if (argv.omx) {
-      openPlayer(`${OMX_EXEC} ${href}`)
+      openPlayer(`${OMX_EXEC} '${href}'`)
     }
 
     function openPlayer (cmd) {


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Single quote every URL being passed as args when launching a player.

If a filename has parentheses, these are not escaped with
encodeURIComponent and will lead the shell to interoperate these
and cause the player subprocess to crash. Since a parentheses denotes
a subshell, this can also be used as an exploit.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**

i've only tested this for `mpv`. Please make sure the quoting makes sense for other players or if I've missed any.