### PR TITLE
Add options to set torrent and dht port

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -72,6 +72,8 @@ const argv = minimist(process.argv.slice(2), {
     'verbose'
   ],
   string: [ // options that are always strings
+    'torrent-port',
+    'dht-port',
     'out',
     'announce',
     'blocklist',
@@ -306,6 +308,8 @@ function runHelp () {
       -b, --blocklist [path]    load blocklist file/http url
       -a, --announce [url]      tracker URL to announce to
       -q, --quiet               don't show UI on stdout
+      --torrentPort [number]    change the torrent seeding port [default: random]
+      --dhtPort [number]        change the dht port [default: random]
       --pip                     enter Picture-in-Picture if supported by the player
       --not-on-top              don't set "always on top" option in player
       --keep-seeding            don't quit when done downloading
@@ -655,7 +659,11 @@ function runSeed (input) {
   const client = new WebTorrent({ blocklist: argv.blocklist })
   client.on('error', fatalError)
 
-  client.seed(input, { announce: argv.announce }, torrent => {
+  client.seed(input, {
+    announce: argv.announce,
+    torrentPort: argv['torrent-port'],
+    dhtPort: argv['dht-port']
+  }, torrent => {
     if (argv.quiet) {
       console.log(torrent.magnetURI)
     }
@@ -702,6 +710,16 @@ function drawTorrent (torrent) {
 
     if (seeding) {
       line(`{green:Info hash: }${torrent.infoHash}`)
+      const seedingInfo = []
+      if (argv['torrent-port']) {
+        seedingInfo.push(`{green:Torrent port: }${argv['torrent-port']}`)
+      }
+      if (argv['dht-port']) {
+        seedingInfo.push(`{green:DHT port: }${argv['dht-port']}`)
+      }
+      if (seedingInfo.length) {
+        line(seedingInfo.join(' '))
+      }
     }
 
     if (playerName) {

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -308,8 +308,8 @@ function runHelp () {
       -b, --blocklist [path]    load blocklist file/http url
       -a, --announce [url]      tracker URL to announce to
       -q, --quiet               don't show UI on stdout
-      --torrent-port [number]    change the torrent seeding port [default: random]
-      --dht-port [number]        change the dht port [default: random]
+      --torrent-port [number]   change the torrent seeding port [default: random]
+      --dht-port [number]       change the dht port [default: random]
       --pip                     enter Picture-in-Picture if supported by the player
       --not-on-top              don't set "always on top" option in player
       --keep-seeding            don't quit when done downloading

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -308,7 +308,7 @@ function runHelp () {
       -b, --blocklist [path]    load blocklist file/http url
       -a, --announce [url]      tracker URL to announce to
       -q, --quiet               don't show UI on stdout
-      --torrentPort [number]    change the torrent seeding port [default: random]
+      --torrent-port [number]    change the torrent seeding port [default: random]
       --dhtPort [number]        change the dht port [default: random]
       --pip                     enter Picture-in-Picture if supported by the player
       --not-on-top              don't set "always on top" option in player

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -309,7 +309,7 @@ function runHelp () {
       -a, --announce [url]      tracker URL to announce to
       -q, --quiet               don't show UI on stdout
       --torrent-port [number]    change the torrent seeding port [default: random]
-      --dhtPort [number]        change the dht port [default: random]
+      --dht-port [number]        change the dht port [default: random]
       --pip                     enter Picture-in-Picture if supported by the player
       --not-on-top              don't set "always on top" option in player
       --keep-seeding            don't quit when done downloading


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
webtorrent doesn't implement uPnP yet (#195, #1437), so it's difficult to seed behind a router. In this case, it's easier to rely on a classic NAT setup with port forwarding. This patch adds two new options to set the torrent seeding port, and the dht port.

**Which issue (if any) does this pull request address?**
It's somehow related to #195, #1437.

**Is there anything you'd like reviewers to focus on?**
nope