### PR TITLE
feat: add playlist option

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -52,7 +52,7 @@ const options = {
     q: { alias: 'quiet', desc: 'Don\'t show UI on stdout' },
     pip: { desc: 'Enter Picture-in-Picture if supported by the player' },
     verbose: { desc: 'Show torrent protocol details' },
-    'playlist': {desc: 'Open files in a playlist if supported by the player'},
+    playlist: { desc: 'Open files in a playlist if supported by the player' },
     'player-args': { desc: 'Add player specific arguments (see example)', type: 'string', requiresArg: true },
     'torrent-port': { desc: 'Change the torrent seeding port', defaultDescription: 'random' },
     'dht-port': { desc: 'Change the dht port', defaultDescription: 'random' },

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -325,7 +325,7 @@ function runHelp () {
 
       Options (advanced):
       --stdout                  standard out (implies --quiet)
-      --playlist                open all files if supported by the player
+      --playlist                open files in a playlist if supported by the player
       -p, --port [number]       change the http server port [default: 8000]
       -a, --announce [url]      tracker URL to announce to
       -b, --blocklist [path]    load blocklist file/http url
@@ -531,7 +531,6 @@ function runDownload (torrentId) {
       // set the first file to the selected index
       all_files = all_files.slice(index, all_files.length).concat(all_files.slice(0, index))
       all_hrefs = all_files.join('\n')
-      console.log(all_hrefs)
     } else {
       href += `/${index}/${encodeURIComponent(torrent.files[index].name)}`
     }

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -70,7 +70,7 @@ const argv = minimist(process.argv.slice(2), {
 
     // Options (advanced)
     'stdout',
-    'play-all',
+    'playlist',
     'quiet',
     'pip',
     'not-on-top',
@@ -325,7 +325,7 @@ function runHelp () {
 
       Options (advanced):
       --stdout                  standard out (implies --quiet)
-      --play-all                open all files if supported by the player
+      --playlist                open all files if supported by the player
       -p, --port [number]       change the http server port [default: 8000]
       -a, --announce [url]      tracker URL to announce to
       -b, --blocklist [path]    load blocklist file/http url
@@ -521,16 +521,17 @@ function runDownload (torrentId) {
       ? `http://${networkAddress()}:${server.address().port}`
       : `http://localhost:${server.address().port}`
     let all_hrefs = ''
-    if (argv['play-all'] && (argv.mpv || argv.mplayer || argv.smplayer)) {
+    if (argv['playlist'] && (argv.mpv || argv.mplayer)) {
       // set the selected to the first file if not specified
       if (typeof argv.select !== 'number') {
         index = 0
       }
       let all_files = []
-      torrent.files.forEach((file, i) => all_files.push(`"${href}/${i}/${encodeURIComponent(file.name)}"`))
+      torrent.files.forEach((file, i) => all_files.push(`${href}/${i}/${encodeURIComponent(file.name)}`))
       // set the first file to the selected index
       all_files = all_files.slice(index, all_files.length).concat(all_files.slice(0, index))
-      all_hrefs = all_files.join(' ')
+      all_hrefs = all_files.join('\n')
+      console.log(all_hrefs)
     } else {
       href += `/${index}/${encodeURIComponent(torrent.files[index].name)}`
     }
@@ -558,13 +559,13 @@ function runDownload (torrentId) {
     } else if (argv.iina) {
       openIINA(`${IINA_EXEC} "${href}"`, `iina://weblink?url=${href}`)
     } else if (argv.mplayer) {
-      (argv['play-all']) ? openPlayer(`${MPLAYER_EXEC} ${all_hrefs}`) : openPlayer(`${MPLAYER_EXEC} "${href}"`)
+      (argv['playlist']) ? openPlayer(`${MPLAYER_EXEC} -playlist <(echo '${all_hrefs}')`) : openPlayer(`${MPLAYER_EXEC} "${href}"`)
     } else if (argv.mpv) {
-      (argv['play-all']) ? openPlayer(`${MPV_EXEC} ${all_hrefs}`) : openPlayer(`${MPV_EXEC} "${href}"`)
+      (argv['playlist']) ? openPlayer(`${MPV_EXEC} --playlist=<(echo '${all_hrefs}')`) : openPlayer(`${MPV_EXEC} "${href}"`)
     } else if (argv.omx) {
       openPlayer(`${OMX_EXEC} "${href}"`)
     } else if (argv.smplayer) {
-      (argv['play-all']) ? openPlayer(`${SMPLAYER_EXEC} ${all_hrefs}`) : openPlayer(`${SMPLAYER_EXEC} "${href}"`)
+      openPlayer(`${SMPLAYER_EXEC} "${href}"`)
     }
 
     function openPlayer (cmd) {


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
I added the --playlist option which will open all the urls of the files in the torrent in a playlist in supported players. I could only get `mpv`, `mplayer` and `vlc` working. If you know how to do this for any of the other players I'm all ears.

**Which issue (if any) does this pull request address?**
#166 

**Is there anything you'd like reviewers to focus on?**
I didn't test the `vlc` on windows, its probably a good idea to do so. This option is most likely incompatible with the `--subtitles` option, I didn't enforce it though, maybe it should be checked and enforced?

I don't have much experience with JS so if I'm not following best practices, feel free to correct me!