### PR TITLE
fix: fix getting `webtorrent` version

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -6,6 +6,7 @@ import ecstatic from 'ecstatic'
 import fs from 'fs'
 import http from 'http'
 import mime from 'mime'
+import { createRequire } from 'module'
 import moment from 'moment'
 import networkAddress from 'network-address'
 import parseTorrent from 'parse-torrent'
@@ -19,8 +20,10 @@ import Yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import open from 'open'
 
-const { version: webTorrentCliVersion } = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url)))
-const { version: webTorrentVersion } = JSON.parse(fs.readFileSync(new URL('../node_modules/webtorrent/package.json', import.meta.url)))
+const require = createRequire(import.meta.url)
+
+const { version: webTorrentCliVersion } = require('../package.json')
+const { version: webTorrentVersion } = require('webtorrent/package.json')
 
 const yargs = Yargs()
 


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Previously, when attempting to use `webtorrent-cli` installed with pnpm, the following error would occur:

```
❯ webtorrent --help
node:fs:585
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, open '/path/to/nodejs/.npm/pnpm-global/5/node_modules/.pnpm/webtorrent-cli@4.0.0/node_modules/webtorrent-cli/node_modules/webtorrent/package.json'
    at Object.openSync (node:fs:585:3)
    at Object.readFileSync (node:fs:453:35)
    at file:///path/to/nodejs/.npm/pnpm-global/5/node_modules/.pnpm/webtorrent-cli@4.0.0/node_modules/webtorrent-cli/bin/cmd.js:23:54
    at ModuleJob.run (node:internal/modules/esm/module_job:185:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:281:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:65:12) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/path/to/nodejs/npm/pnpm-global/5/node_modules/.pnpm/webtorrent-cli@4.0.0/node_modules/webtorrent-cli/node_modules/webtorrent/package.json'
}
```

where `/path/to/nodejs` is the path to my Node.js installation.

This is because the directory structure of the installed `transmission-cli` is like this:

```
.pnpm/webtorrent-cli@4.0.0
 └ node_modules
   ├ other dependencies...
   ├ webtorrent -> .pnpm/webtorrent@1.5.8/node_modules/webtorrent
   │ ├ index.js
   │ ├ package.json
   │ └ etc...
   └ webtorrent-cli
     ├ bin
     ├ package.json
     └ etc...
```

I got a similar error when installing with npm, which uses a somewhat similar directory structure:

```
node_modules
 ├ other dependencies...
 ├ webtorrent
 │ ├ index.js
 │ ├ package.json
 │ └ etc...
 └ webtorrent-cli
   ├ bin
   ├ package.json
   └ etc...
```

This commit uses `module.createRequire` to `require` the `package.json`s.

**Which issue (if any) does this pull request address?**
*none*

**Is there anything you'd like reviewers to focus on?**

Is using `require` the best solution? I considered using `require.resolve` to get the correct `package.json` path instead (`JSON.parse(fs.readFileSync(require.resolve('webtorrent/package.json')))`), but to do that you need to use `createRequire` anyway to get the `require`.