### PR TITLE
fix: npm global install permissions issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ To use WebTorrent in the browser, see [`webtorrent`](https://www.npmjs.com/packa
     **[ut_pex](https://www.npmjs.com/package/ut_pex)**
   - **[protocol extension api](https://www.npmjs.com/package/bittorrent-protocol#extension-api)**
     for adding new extensions
+  - Check all the **[supported BEPs here](https://github.com/webtorrent/webtorrent/blob/master/docs/bep_support.md)**
 
 ### Install
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "preferGlobal": true,
   "repository": {
     "type": "git",
-    "url": "git://github.com/webtorrent/webtorrent-cli.git"
+    "url": "https://github.com/webtorrent/webtorrent-cli.git"
   },
   "scripts": {
     "test": "standard && tape test/*.js",


### PR DESCRIPTION
using ssh url instead of https for repos causes permissions issue if you try to install without ssh keys setup

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Update repo url to http rather than ssh

**Which issue (if any) does this pull request address?**
permission issue when attempting to install using npm without ssh keys setup

**Is there anything you'd like reviewers to focus on?**
N/A