### PR TITLE
fix: properly import a default export with dynamic 'import'

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -509,7 +509,7 @@ async function runDownload (torrentId) {
     }
 
     if (argv.dlna) {
-      const dlnacasts = (await import('dlnacasts'))()
+      const dlnacasts = (await import('dlnacasts')).default()
 
       dlnacasts.on('update', player => {
         const opts = {


### PR DESCRIPTION
when using dynamic import function, default exports need to be referenced explicitly.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#importing_defaults

fixes:
```
verifying existing torrent data...

UNEXPECTED ERROR: If this is a bug in WebTorrent, report it!
OPEN AN ISSUE: https://github.com/webtorrent/webtorrent-cli/issues

DEBUG INFO: webtorrent-cli 4.0.0, webtorrent 1.5.5, node v17.3.0, linux x64, exit 1
file:///usr/lib/webtorrent-cli/bin/cmd.js:512
      const dlnacasts = (await import('dlnacasts'))()
                                                   ^

TypeError: (intermediate value) is not a function
    at onSelection (file:///usr/lib/webtorrent-cli/bin/cmd.js:512:52)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)

Node.js v17.3.0
```

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature

