### PR TITLE
feat: upgrade to dlnacasts2, since dlnacasts is unmaintained

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -509,7 +509,7 @@ async function runDownload (torrentId) {
     }
 
     if (argv.dlna) {
-      const dlnacasts = (await import('dlnacasts')).default()
+      const dlnacasts = (await import('dlnacasts2')).default()
 
       dlnacasts.on('update', player => {
         const opts = {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "chalk": "^4.1.1",
     "common-tags": "^1.8.0",
     "create-torrent": "^5.0.0",
-    "dlnacasts": "^0.1.0",
+    "dlnacasts2": "^0.2.0",
     "ecstatic": "^4.1.4",
     "memory-chunk-store": "^1.3.5",
     "mime": "^2.5.2",


### PR DESCRIPTION
https://www.npmjs.com/package/dlnacasts2
0.2.0 has been published 2 years ago, as opposed to

https://www.npmjs.com/package/dlnacasts
where 0.1.0 has been published 6 years ago

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->



[ ] Documentation update
[ ] Bug fix
[*] New feature