### PR TITLE
fixes https://github.com/webtorrent/webtorrent-cli/issues/245

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -675,7 +675,7 @@ function drawTorrent (torrent) {
 
     line(chalk`{green ${seeding ? 'Seeding' : 'Downloading'}:} {bold ${torrent.name}}`)
 
-    if (seeding) line(chalk`{green Info hash:} ${torrent.infoHash}`)
+    if (seeding) line(chalk`{green magnetURI:} ${torrent.magnetURI}`)
 
     const portInfo = []
     if (argv['torrent-port']) portInfo.push(chalk`{green Torrent port:} ${argv['torrent-port']}`)


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Webtorrent cli seeding currently shows the torrent infohash. However, seeders need to know the magnetURI, which also contains the hash. Therefore this PR changes the printing of infohash to the magnetURI.

**Which issue (if any) does this pull request address?**

https://github.com/webtorrent/webtorrent-cli/issues/245

**Is there anything you'd like reviewers to focus on?**
