### PR TITLE
add polyfill for webrtc to enable web-clients

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -20,6 +20,17 @@ import Yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import open from 'open'
 
+// this adds node support to web-clients
+import { announceList } from 'create-torrent'
+import wrtc from '@koush/wrtc'
+
+// this was in global, but is it needed?
+globalThis.WEBTORRENT_ANNOUNCE = announceList
+  .map(arr => arr[0])
+  .filter(url => url.indexOf('wss://') === 0 || url.indexOf('ws://') === 0)
+
+globalThis.WRTC = wrtc
+
 const { version: webTorrentCliVersion } = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url)))
 const webTorrentVersion = WebTorrent.VERSION
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -19,16 +19,9 @@ import WebTorrent from 'webtorrent'
 import Yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import open from 'open'
-
-// this adds node support to web-clients
-import { announceList } from 'create-torrent'
 import wrtc from '@koush/wrtc'
 
-// this was in global, but is it needed?
-globalThis.WEBTORRENT_ANNOUNCE = announceList
-  .map(arr => arr[0])
-  .filter(url => url.indexOf('wss://') === 0 || url.indexOf('ws://') === 0)
-
+// add polyfill for node
 globalThis.WRTC = wrtc
 
 const { version: webTorrentCliVersion } = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url)))

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/webtorrent/webtorrent-cli/issues"
   },
   "dependencies": {
+    "@koush/wrtc": "^0.5.3",
     "chalk": "^4.1.1",
     "common-tags": "^1.8.0",
     "create-torrent": "^5.0.0",


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Added @koush/wrtc (a working fork of wrtc, as it's not building right now) and setup a default announcellist from create-torrent.

**Which issue (if any) does this pull request address?**

It's roughly the same issue as [here](https://github.com/webtorrent/webtorrent-hybrid/issues/167) with [this PR](https://github.com/webtorrent/webtorrent-hybrid/pull/168). wrtc won't build on modern node versions, and [has no M1 support](https://github.com/node-webrtc/node-webrtc/issues/680). [@koush/wrtc](https://github.com/koush/node-webrtc) does, and this CLI was missing the polyfill import, so it couldn't seed to web. It can, with this small change.

To test:

```
npm i
node ./bin/cmd.js seed YOURFILE --announce wss://tracker.openwebtorrent.com
```
then visit `https://instant.io/#TORRENT_HASH`

