### PR TITLE
fix for download selected files only

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -421,6 +421,16 @@ async function runDownload (torrentId) {
       return errorAndExit(`There's no file that maps to index ${index}`)
     }
 
+    torrent.deselect(0, torrent.pieces.length - 1, false);
+    for (let i = 0; i < torrent.files.length; i++) {
+      const file = torrent.files[i];
+      if (i === index) {
+        file.select();
+      } else {
+        file.deselect();
+      }
+    }
+
     onSelection(index)
   }
 


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
This is a temporary fix for the open issue https://github.com/webtorrent/webtorrent/issues/164 to make webtorrent-cli work as expected until the webtorrent team improves the API. It implements fix https://github.com/webtorrent/webtorrent/issues/164#issuecomment-248395202, which is also referenced in the official webtorrent documentation as relevant (https://github.com/webtorrent/webtorrent/blob/master/docs/api.md#filedeselectpriority), so I decided to create a pull request with that fix.

**Which issue (if any) does this pull request address?**
`argv.select` has no effect and webtorrent-cli downloads the whole torrent instead, even while streaming. Users report this is an unwanted use of resources:

https://github.com/webtorrent/webtorrent-cli/issues/222
https://github.com/webtorrent/webtorrent-cli/issues/250

**Is there anything you'd like reviewers to focus on?**
