### PR TITLE
fix: -s / --select not working

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -302,14 +302,15 @@ async function runDownload (torrentId) {
     announce: argv.announce
   })
 
+  if ('select' in argv) {
+    torrent.so = argv.select.toString()
+  }
+
   if (argv.verbose) {
     torrent.on('warning', handleWarning)
   }
 
   torrent.on('infoHash', () => {
-    if ('select' in argv) {
-      torrent.so = argv.select.toString()
-    }
 
     if (argv.quiet) return
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -311,7 +311,6 @@ async function runDownload (torrentId) {
   }
 
   torrent.on('infoHash', () => {
-
     if (argv.quiet) return
 
     updateMetadata()


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR fixes where `-s` / `--select` does not work as expected, leading to all files being downloaded, rather than the selected. This is done by moving where the `torrent.so` is defined, as this must occur before metadata to ensure reservations aren't made.

Note: This PR does not address the issue that if a piece contains more than just the selected file, it will still be created. e.g. in the Sintel torrent `--select 0` will include the first 5 subtitles and the first 121KB of the .mp4 due to the first piece containing all of this data.

**Which issue (if any) does this pull request address?**
-fixes: https://github.com/webtorrent/webtorrent-cli/issues/222

**Is there anything you'd like reviewers to focus on?**
