### PR TITLE
FIX: Includes version.cjs in .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 *
 !bin/*
+!version.cjs


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR adds an exclusion to `version.cjs` in the `.npmingore`, which is currently excluding this file from the published package, preventing `webtorrent-cli@5.1.1` from working whatsoever.

Following this change, `npm pack` generates a package with all the required files and works as expected:
![image](https://github.com/webtorrent/webtorrent-cli/assets/15065825/1dbb40f5-8241-49a2-8a16-a9a6dcf3711a)

**Which issue (if any) does this pull request address?**
- fixes #312

**Is there anything you'd like reviewers to focus on?**
