### PR TITLE
fix: inconsistent arg parsing

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -476,7 +476,7 @@ async function runDownload (torrentId) {
     }
 
     function openPlayer (args) {
-      cp.spawn(JSON.stringify(args[0]), args.slice(1), { stdio: 'ignore', shell: true })
+      cp.spawn(args[0], args.slice(1), { stdio: 'ignore' })
         .on('error', (err) => {
           if (err) {
             const isMpvFalseError = playerName === 'mpv' && err.code === 4


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
- unescaped url characters breaking arg parsing for players
- don't use `shell: true` so we don't really on the shell's arg parsing, we don't need the shell anyway

**Which issue (if any) does this pull request address?**
- player not launching depending on the url due to chars breaking arg parsing

**Is there anything you'd like reviewers to focus on?**
- I've testing on linux with mpv, this solves my issue, would be good to test on other platforms and players.
